### PR TITLE
카카오 로그인 구현 완료

### DIFF
--- a/src/main/java/com/airline/controller/JoinController.java
+++ b/src/main/java/com/airline/controller/JoinController.java
@@ -182,17 +182,4 @@ System.out.println("kakao controller타는중~~~(join에서 get)");
 				// 닉네임밖에 못받아오기때문에... 기존회원여부 페이지로 이동시킴...ㅜㅜ
 			}
 					
-			
-//
-			@GetMapping("/index")
-			 public String index() {
-			        
-			        return "/join/index";
-			    }
-			    
-//		    @GetMapping(value="/kakao")
-//		    public String login() {
-//		        
-//		        return "/join/index";
-//		    }
 }

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -16,7 +16,7 @@
 <link rel="stylesheet" type="text/css"
 	href="../resources/slick/slick-theme.css" />
 <link rel="stylesheet" href="../resources/css/templatemo-style.css">
-<meta name="referrer" content="no-referrer-when-downgrade" />
+
 <!-- Templatemo style -->
 	<!-- 쿠키값으로 id정보 받아오기 -->
 	<%String cookie = "";
@@ -73,29 +73,11 @@
 						"><button type="button" class="btn btn-primary tm-btn-primary tm-btn-send text-uppercase">카카오 로그인</button></a>
 					</div>
 
-
-
-<div class="wrap">
-     <a class="kakao" href="https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code">
-     	<!-- REST_API키 및 REDIRECT_URI는 본인걸로 수정하세요 -->
-        
-      	<div>카카오톡으로 간편로그인 </div>
-   	</a>
-   	</div>
-
-
-
-
 					<div>
 						<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
 						<input type="hidden" name="${message}" value="${message}"/>
 					</div>
 			</form>
-			
-			
-			
-			
-			
 			
 			<script src="https://t1.kakaocdn.net/kakao_js_sdk/2.5.0/kakao.min.js"
   integrity="sha384-kYPsUbBPlktXsY6/oNHSUDZoTX6+YI51f63jCPEIPFP09ttByAdxd2mEjKuhdqn4" crossorigin="anonymous"></script>
@@ -141,16 +123,8 @@
     if (parts.length === 2) { return parts[1].split(';')[0]; }
   }
 </script>
-			
-			
-			
-			
-			
-			
-			
 		</div>
 		</div>
-
 	</div>
 
 	</div>


### PR DESCRIPTION
카카오 로그인 구현 완료했습니다.
그런데 카카오 권한설정에서 받아올 수 있는 정보가 유저 닉네임뿐이라서... 
기존유저확인(이메일을 받아오지 못해서 통과 불가능)를 통과할 수가 없네요...ㅜㅜ
따라서 
1. 기존유저확인 페이지로 이동
2. 약관동의페이지로 이동(이 경우 카카오로그인시 전부 동의하게 만들고 싶은데 안내할 곳이 없어서.. 문제입니다)
3. 유저정보입력 페이지로 이동(기존유저가 아니라고 가정, 약관전부동의로 가정)

세 가지 방법중에 고민입니다..

참조 : https://developers.kakao.com/console/app/999564/product/login/scope